### PR TITLE
feat : Export des categories GIFT dans to GIFT()

### DIFF
--- a/src/classes.ts
+++ b/src/classes.ts
@@ -67,6 +67,11 @@ export class Question {
     toGift(): string {
         let output = "";
 
+        //Export de la catégorie
+        if (this.category) {
+            output += `$CATEGORY: ${this.category.getPath()}\n\n`;
+        }
+
         // 1. Titre (Optionnel mais recommandé)
         if (this.title) {
             output += `::${this.title}::`;


### PR DESCRIPTION
  - Export des catégories `$CATEGORY:` dans la méthode `toGift()`
   - Préserve le chemin complet de la hiérarchie des catégories
   - Compatible avec les questions sans catégorie
   
   - Import/export d'un fichier avec catégories multiples
   - Vérification de la préservation du format GIFT