### PR TITLE
feat(cli): ajouter une confirmation avant la suppression d'une question

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Exam, Question, QuestionType, AnswerOption } from './classes';
 import { parseGiftFile } from "./parser";
 import * as fs from 'fs';
 import * as path from 'path';
-import { intro, outro, select, spinner, text } from '@clack/prompts';
+import { intro, outro, select, spinner, text, confirm } from '@clack/prompts';
 import { GiftExporter } from "./writer";
 import { VCardGenerator } from "./vcard";
 
@@ -271,11 +271,22 @@ async function main() {
                 });
 
                 if (typeof deleteId === 'number' && deleteId !== -1) {
-                    const removed = exam.questions.splice(deleteId, 1);
-                    console.log(`Deleted: "${removed[0].title}"`);
+                    const qToDelete = exam.questions[deleteId];
+                    
+                    // --- MODIFICATION : AJOUT DE LA CONFIRMATION ---
+                    const shouldDelete = await confirm({
+                        message: `⚠️ Are you sure you want to delete "${qToDelete.title}"? This cannot be undone.`
+                    });
+
+                    if (shouldDelete) {
+                        const removed = exam.questions.splice(deleteId, 1);
+                        console.log(`✅ Deleted: "${removed[0].title}"`);
+                    } else {
+                        console.log("❌ Deletion cancelled.");
+                    }
+                    // -----------------------------------------------
                 }
                 break;
-
             // EF08 : Simulation de passation d'examen
                         // EF08 : Simulation de passation d'examen
 case 'simulate':


### PR DESCRIPTION
 Description
Cette Pull Request ajoute une étape de sécurité lors de la suppression d'une question.
Désormais, l'utilisateur doit confirmer son choix (Oui/Non) avant que la question ne soit définitivement retirée de l'examen. Cela évite les suppressions accidentelles.

 Modifications
- Ajout de l'import `confirm` depuis `@clack/prompts` dans `src/index.ts`.
- Modification du `case 'delete'` : ajout d'un prompt de confirmation avant l'appel à `.splice()`.
- Feedback visuel ajouté : "✅ Deleted" ou "❌ Deletion cancelled".